### PR TITLE
add the runner os release env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set RELEASE_VERSION ENV var
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+      - name: lowercase the runner OS name
+        shell: bash
+        run: |
+          OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          echo "RUNNER_OS=$OS" >> $GITHUB_ENV
       - name: Install latest Rust stable toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
The RUNNER_OS env var was not set in the release job, so it made the release artifact name look like it has an extra "-". This adds the env var.

This var will likely be useful in the future when building for multiple architectures / OSes.